### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Continuous integration
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Suite


### PR DESCRIPTION
Potential fix for [https://github.com/nethunterslabs/http-acl/security/code-scanning/1](https://github.com/nethunterslabs/http-acl/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the actions used in the workflow, the minimal required permissions are `contents: read`. This ensures that the workflow has only the necessary access to repository contents and no write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
